### PR TITLE
feat(date): 日付フォーマット処理を共通化するDateFormatterを導入

### DIFF
--- a/src/pages/app/scripts/p2pquake/data/p2pquake-data.js
+++ b/src/pages/app/scripts/p2pquake/data/p2pquake-data.js
@@ -7,11 +7,24 @@
  * 
  */
 
+import { DateFormatter } from "../../utils/date-formatter/date-formatter.js";
+
 export class P2pquakeItem {
     constructor(item) {
         this.type = item.type;
-        this.publishedTime = item.publishedTime;
-        this.occurredTime = item.occurredTime;
+
+        this.publishedTime = DateFormatter.dateFormat({
+            date: new Date(item.publishedTime),
+            formatType: DateFormatter.formatTypes.FULL
+        });
+
+        this.occurredTime = DateFormatter.dateFormat({
+            date: new Date(item.occurredTime),
+            formatType: DateFormatter.formatTypes.TIME_ONLY_NO_SECONDS
+        });
+
+        this.occurredTime += "頃";
+
         this.scale = item.scale;
         this.magnitude = item.magnitude;
         this.depth = item.depth;
@@ -24,11 +37,9 @@ export class P2pquakeItem {
         this.points = item.points;
     }
 
-
     get scaleText() {
         return (this.scaleTextToJp[String(this.scale)]);
     }
-
 
     get scaleTextToJp() {
         return ({
@@ -45,7 +56,6 @@ export class P2pquakeItem {
         });
     }
 
-
     get depthText() {
         if (this.depth === -1) {
             return ("不明");
@@ -56,7 +66,6 @@ export class P2pquakeItem {
         }
     }
 
-
     get magnitudeText() {
         if (this.magnitude === -1) {
             return ("不明");
@@ -65,16 +74,13 @@ export class P2pquakeItem {
         }
     }
 
-
     get tsunamiText() {
         return (this.tsunamiTextToJp[this.domesticTsunami]);
     }
 
-
     get typeText() {
         return (this.typeTextToJp[this.type]);
     }
-
 
     get typeTextToJp() {
         return ({
@@ -86,7 +92,6 @@ export class P2pquakeItem {
             "Other": "地震情報"
         });
     }
-
 
     get tsunamiTextToJp() {
         return ({
@@ -100,7 +105,6 @@ export class P2pquakeItem {
     }
 }
 
-
 export class P2pquakePoint {
     constructor(item) {
         this.addr = item.addr;
@@ -111,11 +115,9 @@ export class P2pquakePoint {
         this.longitude = item.longitude;
     }
 
-
     get scaleText() {
         return (this.scaleTextToJp[String(this.scale)]);
     }
-
 
     get scaleTextToJp() {
         return ({
@@ -132,7 +134,6 @@ export class P2pquakePoint {
         });
     }
 
-
     get depthText() {
         if (this.depth === -1) {
             return ("不明");
@@ -143,7 +144,6 @@ export class P2pquakePoint {
         }
     }
 
-
     get magnitudeText() {
         if (this.magnitude === -1) {
             return ("不明");
@@ -152,16 +152,13 @@ export class P2pquakePoint {
         }
     }
 
-
     get tsunamiText() {
         return (this.tsunamiTextToJp[this.domesticTsunami]);
     }
 
-
     get typeText() {
         return (this.typeTextToJp[this.type]);
     }
-
 
     get typeTextToJp() {
         return ({
@@ -173,7 +170,6 @@ export class P2pquakePoint {
             "Other": "地震情報"
         });
     }
-
 
     get tsunamiTextToJp() {
         return ({

--- a/src/pages/app/scripts/utils/date-formatter/date-formatter.js
+++ b/src/pages/app/scripts/utils/date-formatter/date-formatter.js
@@ -1,0 +1,59 @@
+/**
+ * 
+ * SSC for Web
+ * 
+ * Copyright (C) Saitama Sora Cam, よね/Yone
+ * 改変や複製を一切禁じます。
+ * 
+ */
+
+export class DateFormatter {
+    constructor() { }
+
+    /**
+     * 
+     * @param {{
+     *     date: Date,
+     *     formatType: string
+     * }} param0 
+     * @returns 
+     */
+    static dateFormat({
+        date,
+        formatType = this.formatTypes.FULL,
+    }) {
+        return [
+            formatType === this.formatTypes.TIME_ONLY || formatType === this.formatTypes.TIME_ONLY_NO_SECONDS ? "" : [
+                date.getFullYear(),
+                "年",
+                DateFormatter.#pad(date.getMonth() + 1),
+                "月",
+                DateFormatter.#pad(date.getDate()),
+                "日 ",
+            ].join(""),
+            formatType === this.formatTypes.DATE_ONLY ? "" : [
+                DateFormatter.#pad(date.getHours()),
+                "時",
+                DateFormatter.#pad(date.getMinutes()),
+                "分",
+                formatType === DateFormatter.formatTypes.TIME_ONLY_NO_SECONDS ? "" : [
+                    DateFormatter.#pad(date.getSeconds()),
+                    "秒",
+                ].join(""),
+            ].join(""),
+        ].join("");
+    }
+
+    static #pad(num) {
+        return num.toString().padStart(2, '0');
+    }
+
+    static get formatTypes() {
+        return {
+            FULL: "FULL",
+            DATE_ONLY: "DATE_ONLY",
+            TIME_ONLY: "TIME_ONLY",
+            TIME_ONLY_NO_SECONDS: "TIME_ONLY_NO_SECONDS",
+        };
+    }
+}


### PR DESCRIPTION
日付や時刻のフォーマット処理をまとめた`DateFormatter`クラスを新規に作成しました。
これにより、コード全体で日付表現が統一され、保守性が向上します。

主な変更点:
- `src/pages/app/scripts/utils/date-formatter/date-formatter.js` に `DateFormatter` を追加
- `P2pquakeItem` クラスで `DateFormatter` を使用するように変更
  - `publishedTime`（発表時刻）を「YYYY年MM月DD日 HH時mm分ss秒」形式でフォーマット
  - `occurredTime`（発生時刻）を「HH時mm分頃」形式でフォーマット
- `p2pquake-data.js` 内の不要な空行を削除し、コードスタイルを整形