### PR TITLE
release: Version 1.1.0

### DIFF
--- a/src/pages/app/index.html
+++ b/src/pages/app/index.html
@@ -21,6 +21,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
+    <!-- icons -->
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
+    <link rel="apple-touch-icon-precomposed" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
+    <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png" title="SSC for Web">
+
+    <!-- manifest -->
+    <link rel="manifest" href="./ssc-web.webmanifest">
+
     <!-- styles -->
     <link rel="stylesheet" href="./styles/common.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">

--- a/src/pages/app/index.html
+++ b/src/pages/app/index.html
@@ -22,9 +22,12 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- icons -->
-    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
-    <link rel="apple-touch-icon-precomposed" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
-    <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png" title="SSC for Web">
+    <link rel="shortcut icon" type="image/x-icon"
+        href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
+    <link rel="apple-touch-icon-precomposed"
+        href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png">
+    <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent.png"
+        title="SSC for Web">
 
     <!-- manifest -->
     <link rel="manifest" href="./ssc-web.webmanifest">
@@ -171,6 +174,16 @@
                     <span id="tsunamiDisplay" class="information-details__display tsunami__display"></span>
                 </dd>
             </dl>
+        </div>
+
+        <div id="expandInformationDetails" class="expand-information-details">
+            <button id="expandInformationDetailsButton" class="expand-information-details__button">
+                <span class="open">
+                    ＜&nbsp;地震情報
+                </span>
+
+                <span class="close">＞&nbsp;閉じる</span>
+            </button>
         </div>
 
         <div id="debugModeMarker" class="debug-mode-marker">

--- a/src/pages/app/index.html
+++ b/src/pages/app/index.html
@@ -164,6 +164,10 @@
                 </dd>
             </dl>
         </div>
+
+        <div id="debugModeMarker" class="debug-mode-marker">
+            <span>Debug Mode</span>
+        </div>
     </main>
 </body>
 

--- a/src/pages/app/scripts/modules/maps/map.js
+++ b/src/pages/app/scripts/modules/maps/map.js
@@ -24,6 +24,7 @@ export class Map {
      * マップスタイルのJSONパス
      */
     static MAP_STYLE = "https://api.maptiler.com/maps/8ec88df9-410c-4968-acf6-b79f27d971f1/style.json?key=GHvHPC7Le16USNGvdnNq";
+    // static MAP_STYLE_YDITS = "https://api.maptiler.com/maps/ba979b60-0cf8-4087-8cdc-5bb919540c08/style.json?key=3ft2uVdfAwtgfKQGIT8U";
 
     /**
      * @param {{
@@ -89,7 +90,8 @@ export class Map {
             icon: L.icon({
                 iconUrl: "./images/hypocenter.png",
                 iconSize: [32, 32]
-            })
+            }),
+            zIndexOffset: 999,
         }).addTo(this.map);
     }
 
@@ -100,30 +102,31 @@ export class Map {
      * @returns 
      */
     setHypocenter(lat, lng) {
-        if (!this.hypocenterMarker) {
-            this.initializeHypocenter(lat, lng);
-            return;
-        }
-
         if (typeof lat !== 'number' || typeof lng !== 'number') {
-            throw new Error("緯度経度が number ではありません");
+            throw new Error("緯度経度が number ではありません at setHypocenter");
         }
-
-        this.hypocenterMarker.setLatLng([lat, lng]);
+        
+        this.initializeHypocenter(lat, lng);
+        // this.hypocenterMarker.setLatLng([lat, lng]);
     }
 
     /**
      * 指定された緯度/経度にマップを移動する
      * 
-     * @param {number} lat
-     * @param {number} lng
+     * @param {L.latLng | LatLng | {lat: number, lng: number } | [number, number] } latLng
      */
-    fitMap(lat, lng) {
-        if (typeof lat !== 'number' || typeof lng !== 'number') {
-            throw new Error("緯度経度が number ではありません");
-        }
+    moveMap(latLng) {
+        this.map.setView(latLng, 8);
+    }
 
-        this.map.setView([lat, lng], 8);
+    /**
+     * 指定された緯度+経度+Boundsにマップを移動する
+     * 
+     * @param {L.latLngBounds | LatLngBounds | LatLng[]} bounds
+     */
+    fitMap(bounds) {
+        this.map.fitBounds(bounds, { maxZoom: 8 });
+        this.map.zoomOut(0.5);
     }
 
     /**
@@ -148,4 +151,11 @@ export class Map {
      * @type {MapApiKey}
      */
     #apiKey;
+
+    /**
+     * Bounds
+     * 
+     * @type {L.LatLngBounds}
+     */
+    bounds;
 }

--- a/src/pages/app/scripts/modules/maps/map.js
+++ b/src/pages/app/scripts/modules/maps/map.js
@@ -19,7 +19,7 @@ export class Map {
      * デフォルトのズームレベル
      */
     static DEFAULT_ZOOM = 5;
-    
+
     /**
      * マップスタイルのJSONパス
      */
@@ -105,7 +105,7 @@ export class Map {
         if (typeof lat !== 'number' || typeof lng !== 'number') {
             throw new Error("緯度経度が number ではありません at setHypocenter");
         }
-        
+
         this.initializeHypocenter(lat, lng);
         // this.hypocenterMarker.setLatLng([lat, lng]);
     }

--- a/src/pages/app/scripts/modules/p2pquake/data/p2pquake-data.js
+++ b/src/pages/app/scripts/modules/p2pquake/data/p2pquake-data.js
@@ -93,6 +93,10 @@ export class P2pquakeItem {
      * 震度の文字列表現
      */
     get scaleText() {
+        if (this.type === "Destination") {
+            return "-";
+        }
+
         return P2pquakeItem.SCALE_TEXT_TO_JP[String(this.scale)] || P2pquakeItem.SCALE_TEXT_TO_JP["-1"];
     }
 
@@ -100,6 +104,10 @@ export class P2pquakeItem {
      * 震源深さの文字列表現
      */
     get depthText() {
+        if (this.type === "ScalePrompt") {
+            return ("調査中");
+        }
+
         if (this.depth === -1) {
             return ("不明");
         } else if (this.depth === 0) {
@@ -113,6 +121,10 @@ export class P2pquakeItem {
      * 地震の規模 (マグニチュード Mj) の文字列表現
      */
     get magnitudeText() {
+        if (this.type === "ScalePrompt") {
+            return ("調査中");
+        }
+
         if (this.magnitude === -1) {
             return ("不明");
         } else {

--- a/src/pages/app/scripts/modules/p2pquake/p2pquake.js
+++ b/src/pages/app/scripts/modules/p2pquake/p2pquake.js
@@ -20,11 +20,11 @@ export class P2pquake {
 
     /**
      * @param {{
-     *     onGotNewEarthquakeInformation: ({ data: P2pquakeItem[] }) => any,
+     *     onGotNewEarthquakeInformation: async ({ data: P2pquakeItem[] }) => Promise<any>,
      * }}
      */
     constructor({
-        onGotNewEarthquakeInformation = ({ data }) => { },
+        onGotNewEarthquakeInformation = async ({ data }) => { },
     }) {
         if (typeof onGotNewEarthquakeInformation !== "function") {
             throw new Error("`onGotNewEarthquakeInformation` が `function` コールバック関数ではありません");
@@ -39,7 +39,15 @@ export class P2pquake {
      * @returns {Promise<void>}
      */
     async getEarthquakeInfo() {
-        const response = await fetch(P2pquake.API_ENDPOINT);
+        let url;
+
+        if (P2pquake.debugMode === true) {
+            url = P2pquake.API_ENDPOINT + "&offset=" + new Date().getSeconds();
+        } else {
+            url = P2pquake.API_ENDPOINT;
+        }
+
+        const response = await fetch(url);
         const data = await response.json();
 
         if (this.lastId === data[0].id) {
@@ -73,7 +81,7 @@ export class P2pquake {
         this.#latestData = formattedData;
 
         try {
-            this.#onGotNewEarthquakeInformationCallback({ data: formattedData });
+            await this.#onGotNewEarthquakeInformationCallback({ data: formattedData });
         } catch (error) {
             console.error('コールバックの実行中にエラーが発生しました', error);
         }
@@ -91,7 +99,7 @@ export class P2pquake {
     /**
      * 新しい地震情報を取得したときのコールバック関数
      * 
-     * @type {({ data: P2pquakeItem[] }) => any}
+     * @type {async ({ data: P2pquakeItem[] }) => Promise<any>}
      */
     #onGotNewEarthquakeInformationCallback;
 
@@ -101,4 +109,6 @@ export class P2pquake {
      * @type {P2pquakeItem[]}
      */
     #latestData;
+
+    static debugMode = false;
 }

--- a/src/pages/app/scripts/ssc-web/ssc-web.js
+++ b/src/pages/app/scripts/ssc-web/ssc-web.js
@@ -92,8 +92,21 @@ export class SSCWeb {
             apiKey: this.#mapApiKey,
         });
 
+        if (new URL(window.location.href).searchParams.get("debug") === "enable") {
+            P2pquake.debugMode = true;
+            console.debug("⚠️: デバッグモードが有効です。");
+            document.getElementById("debugModeMarker").classList.add("enabled");
+
+            setTimeout(() => {
+                document.getElementById("debugModeMarker").classList.add("highlight");
+                setTimeout(() => {
+                    document.getElementById("debugModeMarker").classList.remove("highlight");
+                }, 2000)
+            }, 1000)
+        }
+
         this.p2pquake = new P2pquake({
-            onGotNewEarthquakeInformation: ({ data }) => this.#onGotNewEarthquakeInformation({ data }),
+            onGotNewEarthquakeInformation: async ({ data }) => await this.#onGotNewEarthquakeInformation({ data }),
         });
 
         await this.map.initialize();
@@ -148,9 +161,9 @@ export class SSCWeb {
      * @param {{
      *     data: P2pquakeItem[],
      * }}
-     * @returns {void}
+     * @returns {Promise<void>}
      */
-    #onGotNewEarthquakeInformation({ data }) {
+    async #onGotNewEarthquakeInformation({ data }) {
         if (!Array.isArray(data) || data.length === 0) {
             throw new Error("`data` が配列ではないか、空の配列です");
         }
@@ -172,15 +185,10 @@ export class SSCWeb {
 
         const lat = latestData?.hypocenter?.lat;
         const lng = latestData?.hypocenter?.lng;
-
-        if (typeof lat !== "number" || typeof lng !== "number") {
-            throw new Error("震源の緯度経度がnumberではありません。");
-        }
+        this.map.bounds = L.latLngBounds();
 
         try {
             this.map.removeAllLayers();
-            this.map.fitMap(lat, lng);
-            setTimeout(() => this.map.setHypocenter(lat, lng));
         } catch (error) {
             throw new Error("新しい地震情報のマップ更新中にエラーが発生しました");
         }
@@ -209,9 +217,6 @@ export class SSCWeb {
                     prefFlag.push(point.pref);
                 }
 
-
-                console.debug(flag);
-
                 let latLng = await AddressSearch.getLatLng(point.pref + point.addr);
                 let iconUrl = Icons.INT_ICONS[String(point.scale)] || Icons.INT_ICONS["-1"];
 
@@ -225,7 +230,25 @@ export class SSCWeb {
                     "latitude": latLng.lat,
                     "longitude": latLng.lng,
                 }));
+
+                this.map.bounds.extend(L.latLng(latLng.lat, latLng.lng));
             });
+        } catch (error) {
+            console.error(error);
+        }
+
+        try {
+            if (latestData.type !== "ScalePrompt") {
+                setTimeout(() => this.map.setHypocenter(lat, lng), 1000);
+                const hypocenterLatLng = L.latLng(lat, lng);
+                this.map.bounds.extend(hypocenterLatLng);
+            }
+            setTimeout(() => {
+                this.map.fitMap(this.map.bounds);
+            }, 2000);
+            setTimeout(() => {
+                this.map.fitMap(this.map.bounds);
+            }, 8000);
         } catch (error) {
             console.error(error);
         }

--- a/src/pages/app/scripts/ssc-web/ssc-web.js
+++ b/src/pages/app/scripts/ssc-web/ssc-web.js
@@ -26,7 +26,7 @@ export class SSCWeb {
      * 
      * @type {Version}
      */
-    static VERSION = new Version(1, 0, 0, Version.levels.stable);
+    static VERSION = new Version(1, 1, 0, Version.levels.stable);
 
     /**
      * アプリケーション名

--- a/src/pages/app/scripts/ssc-web/ssc-web.js
+++ b/src/pages/app/scripts/ssc-web/ssc-web.js
@@ -105,6 +105,8 @@ export class SSCWeb {
             }, 1000)
         }
 
+        document.getElementById("expandInformationDetailsButton").addEventListener("click", () => this.#onClickInformationDetailsButton());
+
         this.p2pquake = new P2pquake({
             onGotNewEarthquakeInformation: async ({ data }) => await this.#onGotNewEarthquakeInformation({ data }),
         });
@@ -153,6 +155,14 @@ export class SSCWeb {
         this.elementsManager.getFromCache('#magnitudeDisplay');
         this.elementsManager.getFromCache('#depthDisplay');
         this.elementsManager.getFromCache('#tsunamiDisplay');
+    }
+
+    /**
+     * @returns {void}
+     */
+    #onClickInformationDetailsButton() {
+        this.elementsManager.getFromCache("#informationDetails").classList.toggle("enabled");
+        this.elementsManager.getFromCache("#expandInformationDetails").classList.toggle("enabled");
     }
 
     /**

--- a/src/pages/app/ssc-web.webmanifest
+++ b/src/pages/app/ssc-web.webmanifest
@@ -1,0 +1,26 @@
+{
+    "manifest_version": 3,
+    "name": "SSC for Web",
+    "short_name": "SSC-Web",
+    "description": "Saitama Sora Cam (SSC) が提供する防災情報Webアプリケーション。",
+    "version": "1.0.0",
+    "minimum_chrome_version": "116",
+    "scope": "./",
+    "start_url": "./index.html",
+    "display": "standalone",
+    "display_override": [
+        "standalone"
+    ],
+    "icons": [
+        {
+            "src": "https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent_512px.png",
+            "type": "image/png",
+            "sizes": "512x512"
+        },
+        {
+            "src": "https://cdn.ydits.net/images/ydits-ssc-logos/ydits_for_ssc_icon_transparent_192px.png",
+            "type": "image/png",
+            "sizes": "192x192"
+        }
+    ]
+}

--- a/src/pages/app/ssc-web.webmanifest
+++ b/src/pages/app/ssc-web.webmanifest
@@ -3,7 +3,7 @@
     "name": "SSC for Web",
     "short_name": "SSC-Web",
     "description": "Saitama Sora Cam (SSC) が提供する防災情報Webアプリケーション。",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "minimum_chrome_version": "116",
     "scope": "./",
     "start_url": "./index.html",

--- a/src/pages/app/styles/common.css
+++ b/src/pages/app/styles/common.css
@@ -229,3 +229,31 @@ main {
 .ydits-copyright__image {
     width: 4.5rem;
 }
+
+/* debug-mode-marker */
+
+.debug-mode-marker {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background-color: #e62;
+    color: #fff;
+    opacity: 0.8;
+    border-radius: 100vw;
+    padding: 0.2em 0.5em;
+    z-index: 9999;
+
+    display: none;
+
+    transition: font-size 0.3s,
+                background-color 0.3s;
+
+    &.enabled {
+        display: block;
+    }
+
+    &.highlight {
+        background-color: #f44;
+        font-size: 3rem;
+    }
+}

--- a/src/pages/app/styles/common.css
+++ b/src/pages/app/styles/common.css
@@ -51,7 +51,12 @@ main {
 
 .map {
     width: calc(100vw - var(--information-details--width));
-    height: 100vh;
+    height: 100dvh;
+
+    @media (max-width: 768px) {
+        transition: width 0.3s;
+        width: 100vw;
+    }
 }
 
 .map__item {
@@ -98,11 +103,24 @@ main {
 
     width: var(--information-details--width);
     height: 100vh;
-    border-left: 1px solid #fff2;
+    border-left: 1px solid #fff4;
 
     padding: 0.5rem 0.8rem;
     background-color: #111;
     color: #fff;
+
+    @media (max-width: 768px) {
+        position: fixed;
+        top: 0;
+        right: -100%;
+        transition: right 0.3s;
+        z-index: calc(var(--map-item--z-index) + 1);
+
+        &.enabled {
+            right: 0;
+        }
+    }
+
 }
 
 .information-details__item {
@@ -129,12 +147,14 @@ main {
     font-size: 1.2rem;
     font-weight: bold;
     color: #ccc;
+    text-wrap: nowrap;
 }
 
 .information-details__description {
     display: flex;
     justify-content: end;
     width: 50%;
+    text-wrap: nowrap;
 }
 
 .information-details__display {
@@ -162,6 +182,52 @@ main {
 .magnitude__display {
     font-size: 2rem;
     font-weight: bold;
+}
+
+/* expand-information-details */
+
+.expand-information-details {
+    position: fixed;
+    top: 42vh;
+    right: 0;
+    height: fit-content;
+    z-index: calc(var(--map-item--z-index) + 2);
+
+    transition: right 0.3s;
+
+    & .close {
+        display: none;
+    }
+
+    &.enabled {
+        right: calc(var(--information-details--width) - 1px);
+
+        & .open {
+            display: none;
+        }
+
+        & .close {
+            display: block;
+        }
+    }
+}
+
+.expand-information-details__button {
+    display: none;
+    writing-mode: vertical-rl;
+    text-orientation: upright;
+    border: none;
+    border-left: 1px solid #fff4;
+    border-top: 1px solid #fff4;
+    border-bottom: 1px solid #fff4;
+    border-radius: 0.5em 0 0 0.5em;
+    padding: 0.5em 0.2em;
+    background-color: #111;
+    color: var(--map-item--color);
+
+    @media (max-width: 768px) {
+        display: block;
+    }
 }
 
 /* icon-legends */
@@ -246,7 +312,7 @@ main {
     display: none;
 
     transition: font-size 0.3s,
-                background-color 0.3s;
+        background-color 0.3s;
 
     &.enabled {
         display: block;


### PR DESCRIPTION
## 変更内容

### 機能

- [x] アプリアイコンの設定
- [x] PWA対応
- [x] UIのモバイル対応
- [x] デバッグモードの追加
  - [x] URLパラメータに `?debug=enable` が含まれる場合にデバッグモードを有効にする
  - [x] デバッグモードが有効のとき、P2P地震情報のデータ処理をデバッグするために、過去のデータを毎回取得する
  - [x] デバッグモードが有効のとき、アプリ右下にマーカーを表示する
- [x] 電文種別が震度速報のとき、地震の規模と震源の深さを『調査中』とする

### 修正

- [x] 新規の地震情報を取得した際のマップ関連の処理を完全に修正
- [x] Boundsの処理を修正
  - [x] 震度分布のマップズームを正しく調節するように修正