### PR TITLE
feat: 震度分布マップの震央マーカーを常に手前に表示

### DIFF
--- a/src/pages/app/scripts/ssc-web/features/maps/map.js
+++ b/src/pages/app/scripts/ssc-web/features/maps/map.js
@@ -93,7 +93,7 @@ export class Map {
                 iconUrl: "./images/v2/hypocenter.png",
                 iconSize: [32, 32]
             }),
-            zIndexOffset: 9,
+            zIndexOffset: 100,
         }).addTo(this.map);
     }
 

--- a/src/pages/app/scripts/ssc-web/ssc-web.js
+++ b/src/pages/app/scripts/ssc-web/ssc-web.js
@@ -404,7 +404,7 @@ export class SSCWeb {
                     Icons.INT_ICONS?.["ssc-v2"]?.["-1"]
                 );
 
-                this.map.newPoint(latLng.lat, latLng.lng, iconUrl, point.scale * 10);
+                this.map.newPoint(latLng.lat, latLng.lng, iconUrl, point.scale);
 
                 points.push(new P2pquakePoint({
                     "addr": point.addr,


### PR DESCRIPTION
## 概要

震度分布マップの震央マーカーを常に手前に表示し、確認しやすくします。

## 変更内容

### Features

- #27
  - **震源マーカーの表示優先度を引き上げ**: 震源マーカーの `zIndexOffset` を `9` から `100` に変更し、他の地点マーカーと重なった場合でも震源位置を視認しやすくしました。
  - **観測点マーカーのスケール指定を修正**: `map.newPoint()` に渡す値を `point.scale * 10` から `point.scale` に変更し、震度スケール値をそのまま利用するようにしました。

## 範囲

この PR の変更範囲は、SSC-Web の地図表示におけるマーカー描画処理に限定しています。対象は震源マーカーの重なり順制御と、P2Pquake 観測点マーカー生成時のスケール指定のみであり、データ取得処理、住所検索処理、アイコン選択ロジック、地図の表示範囲計算には変更を加えていません。
